### PR TITLE
Log: add caller skip

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -41,7 +41,7 @@ func configureLogger(l *zap.Logger, service string) (Logger, func(), error) {
 		l.Sync()
 	}
 
-	return Logger{s: l.Sugar()}, cleanup, nil
+	return Logger{s: l.Sugar()}.AddCallerSkip(1), cleanup, nil
 }
 
 // Init initializes the logging system and sets the "service" key to the provided argument.


### PR DESCRIPTION
Not adding any tests for this because its pretty trivial and the work to figure out how to test it from zap's pov is I think not worth it. The caller context is not being stored in the observer logger.