### PR TITLE
add env.Bool for parsing bool environment variables

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -7,10 +7,28 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 )
+
+// Bool parses given environment variables as a boolean, or returns the default if the environment variable is empty/unset.
+// If the value is empty or unset it will return the first value of def or false if none is given.
+// Evaluates true if the value case-insensitive matches 1|t|true|y|yes.
+func Bool(name string, def ...bool) bool {
+	if v := os.Getenv(name); v != "" {
+		v = strings.ToLower(v)
+		if v == "1" || v == "t" || v == "true" || v == "y" || v == "yes" {
+			return true
+		}
+		return false
+	}
+	if len(def) > 0 {
+		return def[0]
+	}
+	return false
+}
 
 // Get retrieves the value of the environment variable named by the key.
 // If the value is empty or unset it will return the first value of def or "" if none is given

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -10,6 +10,57 @@ import (
 	"time"
 )
 
+func ExampleBool() {
+	name := "some_bool_environment_variable_that_is_not_set"
+	os.Unsetenv(name)
+
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, true))
+	fmt.Println(Bool(name, true, false))
+	fmt.Println(Bool(name, false, true))
+
+	os.Setenv(name, "true")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, false))
+	os.Setenv(name, "false")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, true))
+	os.Setenv(name, "t")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, false))
+	os.Setenv(name, "f")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, true))
+	os.Setenv(name, "1")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, false))
+	os.Setenv(name, "0")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, true))
+	os.Setenv(name, "random-value")
+	fmt.Println(Bool(name))
+	fmt.Println(Bool(name, true))
+	// Output:
+	// false
+	// true
+	// true
+	// false
+	// true
+	// true
+	// false
+	// false
+	// true
+	// true
+	// false
+	// false
+	// true
+	// true
+	// false
+	// false
+	// false
+	// false
+}
+
 func ExampleGet() {
 	name := "some_environment_variable_that_is_not_set"
 	os.Unsetenv(name)


### PR DESCRIPTION
I've exported `IsTrue` so it may be used in separately for instances where they want to check if the environment variable is empty.