### PR TITLE
Use kernel-assigned port in grpc/TestListen/Serve_calls_s.listen_if_necessary

### DIFF
--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -347,6 +347,7 @@ func TestListen(t *testing.T) {
 		s, err := NewServer(l, defSrv)
 		assert.NoError(t, err)
 		assert.NotNil(t, s)
+		s.port = 0
 
 		go func() {
 			if err := s.Serve(); err != nil {


### PR DESCRIPTION
Fixes #46